### PR TITLE
Serialise np tag correctly as np= instead of sp=

### DIFF
--- a/src/DmarcRecord.php
+++ b/src/DmarcRecord.php
@@ -333,7 +333,7 @@ class DmarcRecord
         $record .= $this->aspf ? "aspf={$this->getRealAspfValue($this->aspf)}; " : '';
         $record .= $this->reporting ? 'fo='.implode(':', array_map(fn (string $v) => $this->getRealReportingOption($v), $this->reporting)).'; ' : '';
         $record .= $this->interval ? "ri=$this->interval; " : '';
-        $record .= $this->np ? "sp=$this->np; " : '';
+        $record .= $this->np ? "np=$this->np; " : '';
         $record .= $this->psd ? "psd=$this->psd; " : '';
         $record .= $this->t ? "t=$this->t; " : '';
 

--- a/tests/DmarcRecordTest.php
+++ b/tests/DmarcRecordTest.php
@@ -230,7 +230,7 @@ describe('string output', function (): void {
         expect((string) $record)->toContain('fo=d:s');
     });
 
-    it('includes np (as sp) when only np is set', function (): void {
+    it('includes np when only np is set', function (): void {
         $record = new DmarcRecord;
         $record->version('DMARC1')
             ->policy('none')
@@ -241,7 +241,8 @@ describe('string output', function (): void {
         expect($output)
             ->toContain('v=DMARC1;')
             ->toContain('p=none;')
-            ->toContain('sp=reject;');
+            ->toContain('np=reject;')
+            ->not->toContain('sp=reject;');
     });
 
     it('includes psd and t when set', function (): void {


### PR DESCRIPTION
## Summary

Fixes #26.

The `np` (Non-Existent Subdomain Policy) tag was being serialised as `sp=` in `__toString()`, colliding with the subdomain policy tag. This meant any record with `np` set would produce an invalid DMARC string — receivers would see a duplicate or incorrect `sp=` and never see `np=`.