### PR TITLE
fix: silently ignore unknown tags in parse()

### DIFF
--- a/src/DmarcRecord.php
+++ b/src/DmarcRecord.php
@@ -290,6 +290,7 @@ class DmarcRecord
                 'np' => $builder->nonExistentSubdomainPolicy($value),
                 'psd' => $builder->publicSuffixDomainPolicy($value),
                 't' => $builder->testingMode($value),
+                default => null,
             });
 
         return $builder;

--- a/tests/DmarcRecordTest.php
+++ b/tests/DmarcRecordTest.php
@@ -421,6 +421,12 @@ describe('parsing', function (): void {
         ['fo', 's', 'reporting', ['spf']],
     ]);
 
+    it('silently ignores unknown tags', function (): void {
+        $instance = DmarcRecord::parse('v=DMARC1; p=none; unknowntag=value; anothertag=123;');
+        expect($instance->version)->toEqual('DMARC1');
+        expect($instance->policy)->toEqual('none');
+    });
+
     it('fails with missing required fields', function (string $record, string $expectedException): void {
         expect(fn () => DmarcRecord::parse($record))
             ->toThrow(InvalidArgumentException::class, $expectedException);


### PR DESCRIPTION
## Summary

Fixes #25.

Adds `default => null` to the `match` expression in `parse()`, so unrecognised tags are silently skipped rather than throwing an `UnhandledMatchError`. This is consistent with RFC 7489 forward-compatibility expectations — parsers should tolerate tags they don't understand.

Note: invalid values on *known* tags (e.g. `adkim=invalid`) continue to throw as before — those errors come from within the match arms themselves and are unaffected by this change.