### PR TITLE
RFC 9989 (DMARCbis) additive support  rua/ruf lists + pct/ri deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `dmarc-record-builder` will be documented in this file.
 
+## 3.1.0 - 2026-06-18
+
+### Added
+
+- **`rua()` and `ruf()` now accept an array of addresses** in addition to a single string, supporting the comma-separated URI list defined in RFC 9989 (DMARCbis). Each address is validated to start with `mailto:`; the value is stored and emitted as a comma-separated list (e.g. `rua=mailto:a@example.com,mailto:b@example.com`). Single-string usage is unchanged.
+
+### Deprecated
+
+- **`pct()` and `interval()`** — RFC 9989 (DMARCbis) removed the `pct` and `ri` tags. Both methods continue to work unchanged and are retained for backwards compatibility, but are scheduled for removal in `4.0.0`.
+
 ## 3.0.0 - 2026-03-20
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ echo $record;
 
 Tags with a `null` value are omitted from the output string. Only `v` and `p` are always emitted.
 
+> **Note:** RFC 9989 (DMARCbis) removed the `pct` and `ri` tags. `pct()` and `interval()` are deprecated and retained only for backwards compatibility; they are scheduled for removal in `4.0.0`.
+
 ### Tag Details
 
 #### `policy()` / `subdomainPolicy()` / `nonExistentSubdomainPolicy()`
@@ -164,6 +166,13 @@ URIs for receiving DMARC reports. Must be prefixed with `mailto:`.
 ```php
 ->rua('mailto:dmarc@example.com')
 ->ruf('mailto:dmarc-forensic@example.com')
+```
+
+Both tags also accept an array of addresses (RFC 9989 — comma-separated list):
+
+```php
+->rua(['mailto:dmarc@example.com', 'mailto:backup@example.com'])
+// rua=mailto:dmarc@example.com,mailto:backup@example.com
 ```
 
 #### `adkim()` / `aspf()`

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Controls how the receiving mail server handles messages that fail DMARC checks.
 
 #### `pct()`
 
+> **Deprecated (RFC 9989)** — DMARCbis removed the `pct` tag. Still functional; scheduled for removal in `4.0.0`.
+
 The percentage of messages the policy is applied to (1–100). Useful for gradual rollout. Omit to apply the policy to all messages.
 
 #### `rua()` / `ruf()`
@@ -208,6 +210,8 @@ Multiple values produce a colon-separated `fo` tag:
 Duplicate values are silently deduplicated. `'all'` and `'any'` are mutually exclusive — passing both throws an `InvalidArgumentException`.
 
 #### `interval()`
+
+> **Deprecated (RFC 9989)** — DMARCbis removed the `ri` tag. Still functional; scheduled for removal in `4.0.0`.
 
 How often (in seconds) receivers should send aggregate reports. The RFC default is 86400 (24 hours).
 

--- a/src/DmarcRecord.php
+++ b/src/DmarcRecord.php
@@ -103,6 +103,10 @@ class DmarcRecord
         return $this;
     }
 
+    /**
+     * @deprecated RFC 9989 (DMARCbis) removed the "pct" tag. Retained for
+     *             backwards compatibility; scheduled for removal in 4.0.0.
+     */
     public function pct(?int $percentage): static
     {
         $this->pct = $percentage;
@@ -186,6 +190,10 @@ class DmarcRecord
         return $this;
     }
 
+    /**
+     * @deprecated RFC 9989 (DMARCbis) removed the "ri" tag. Retained for
+     *             backwards compatibility; scheduled for removal in 4.0.0.
+     */
     public function interval(?int $interval): static
     {
         $this->interval = $interval;

--- a/src/DmarcRecord.php
+++ b/src/DmarcRecord.php
@@ -46,8 +46,8 @@ class DmarcRecord
         ?string $policy = 'none',
         ?string $subdomain_policy = null,
         ?int $pct = null,
-        ?string $rua = null,
-        ?string $ruf = null,
+        string|array|null $rua = null,
+        string|array|null $ruf = null,
         ?string $adkim = null,
         ?string $aspf = null,
         string|array $reporting = [],
@@ -110,42 +110,38 @@ class DmarcRecord
         return $this;
     }
 
-    public function rua(?string $mailto): static
+    public function rua(string|array|null $mailto): static
     {
-        if (is_null($mailto)) {
-            $this->rua = $mailto;
-
-            return $this;
-        }
-
-        Assert::startsWith(
-            value: $mailto,
-            prefix: 'mailto:',
-            message: 'rua mailto address should start with "mailto:"'
-        );
-
-        $this->rua = $mailto;
+        $this->rua = is_null($mailto) ? null : $this->normalizeReportUris($mailto, 'rua');
 
         return $this;
     }
 
-    public function ruf(?string $mailto): static
+    public function ruf(string|array|null $mailto): static
     {
-        if (is_null($mailto)) {
-            $this->ruf = $mailto;
-
-            return $this;
-        }
-
-        Assert::startsWith(
-            value: $mailto,
-            prefix: 'mailto:',
-            message: 'ruf mailto address should start with "mailto:"'
-        );
-
-        $this->ruf = $mailto;
+        $this->ruf = is_null($mailto) ? null : $this->normalizeReportUris($mailto, 'ruf');
 
         return $this;
+    }
+
+    protected function normalizeReportUris(string|array $value, string $tag): ?string
+    {
+        $items = is_array($value) ? $value : explode(',', $value);
+
+        $items = array_values(array_filter(
+            array_map('trim', $items),
+            fn (string $item): bool => $item !== ''
+        ));
+
+        foreach ($items as $item) {
+            Assert::startsWith(
+                value: $item,
+                prefix: 'mailto:',
+                message: sprintf('%s mailto address should start with "mailto:"', $tag)
+            );
+        }
+
+        return $items === [] ? null : implode(',', $items);
     }
 
     public function adkim(?string $value): static
@@ -235,8 +231,8 @@ class DmarcRecord
         ?string $policy = 'none',
         ?string $subdomain_policy = null,
         ?int $pct = null,
-        ?string $rua = null,
-        ?string $ruf = null,
+        string|array|null $rua = null,
+        string|array|null $ruf = null,
         ?string $adkim = null,
         ?string $aspf = null,
         string|array $reporting = [],

--- a/tests/DmarcRecordTest.php
+++ b/tests/DmarcRecordTest.php
@@ -138,6 +138,39 @@ describe('fluent methods', function (): void {
         $record->reporting([]);
         expect($record->reporting)->toEqual([]);
     });
+
+    it('accepts an array of addresses for rua and stores a comma-joined string', function (): void {
+        $record = new DmarcRecord;
+        $record->rua(['mailto:a@example.com', 'mailto:b@example.com']);
+        expect($record->rua)->toEqual('mailto:a@example.com,mailto:b@example.com');
+    });
+
+    it('accepts an array of addresses for ruf and stores a comma-joined string', function (): void {
+        $record = new DmarcRecord;
+        $record->ruf(['mailto:a@example.com', 'mailto:b@example.com']);
+        expect($record->ruf)->toEqual('mailto:a@example.com,mailto:b@example.com');
+    });
+
+    it('still accepts a single string for rua and ruf', function (): void {
+        $record = new DmarcRecord;
+        $record->rua('mailto:a@example.com')->ruf('mailto:b@example.com');
+        expect($record->rua)->toEqual('mailto:a@example.com');
+        expect($record->ruf)->toEqual('mailto:b@example.com');
+    });
+
+    it('trims whitespace around rua list items', function (): void {
+        $record = new DmarcRecord;
+        $record->rua(['mailto:a@example.com', '  mailto:b@example.com  ']);
+        expect($record->rua)->toEqual('mailto:a@example.com,mailto:b@example.com');
+    });
+
+    it('clears rua and ruf when given an empty array', function (): void {
+        $record = new DmarcRecord;
+        $record->rua(['mailto:a@example.com'])->ruf(['mailto:b@example.com']);
+        $record->rua([])->ruf([]);
+        expect($record->rua)->toBeNull();
+        expect($record->ruf)->toBeNull();
+    });
 });
 
 describe('validation', function (): void {
@@ -209,6 +242,16 @@ describe('validation', function (): void {
         expect(fn () => DmarcRecord::create(t: $invalidT))
             ->toThrow(InvalidArgumentException::class);
     })->with(['x', 'invalid', 'bad']);
+
+    it('rejects an array containing a non-mailto rua address', function (): void {
+        expect(fn () => DmarcRecord::create(rua: ['mailto:a@example.com', 'invalid@example.com']))
+            ->toThrow(InvalidArgumentException::class, 'rua mailto address should start with "mailto:"');
+    });
+
+    it('rejects an array containing a non-mailto ruf address', function (): void {
+        expect(fn () => DmarcRecord::create(ruf: ['mailto:a@example.com', 'invalid@example.com']))
+            ->toThrow(InvalidArgumentException::class, 'ruf mailto address should start with "mailto:"');
+    });
 });
 
 describe('string output', function (): void {
@@ -328,6 +371,12 @@ describe('string output', function (): void {
         ['reporting', ['dkim'], 'd', 'fo'],
         ['reporting', ['spf'], 's', 'fo'],
     ]);
+
+    it('renders a multi-address rua as a comma-separated list', function (): void {
+        $record = new DmarcRecord('DMARC1', 'none');
+        $record->rua(['mailto:a@example.com', 'mailto:b@example.com']);
+        expect((string) $record)->toContain('rua=mailto:a@example.com,mailto:b@example.com;');
+    });
 });
 
 describe('parsing', function (): void {
@@ -348,6 +397,13 @@ describe('parsing', function (): void {
             ->interval->toEqual(3600)
             ->and((string) $instance)
             ->toEqual($record);
+    });
+
+    it('parses a comma-separated rua list and round-trips it', function (): void {
+        $record = 'v=DMARC1; p=none; rua=mailto:a@example.com,mailto:b@example.com;';
+        $instance = DmarcRecord::parse($record);
+        expect($instance->rua)->toEqual('mailto:a@example.com,mailto:b@example.com');
+        expect((string) $instance)->toContain('rua=mailto:a@example.com,mailto:b@example.com;');
     });
 
     it('parses np, psd, and t values', function (): void {


### PR DESCRIPTION
## Summary

Adds the non-breaking portion of RFC 9989 (DMARCbis) support, targeting a `3.1.0` release. Only RFC 9989 is relevant to a record *builder* — RFC 9990/9991 define report document formats, which are out of scope (see issue discussion).

- **`rua()` / `ruf()` accept a list of addresses** — signatures widen to `string|array|null`, normalised through a shared `normalizeReportUris()` helper and stored/emitted as a comma-separated list per RFC 9989. Single-string usage is unchanged; public `$rua`/`$ruf` properties stay `?string`, so the change is fully backwards compatible.
- **`pct()` / `interval()` deprecated** — RFC 9989 removed the `pct` and `ri` tags. Both methods still work unchanged (kept for backwards compatibility) and are now `@deprecated`, scheduled for removal in a future `4.0.0`.
- **Docs** — README (array usage + inline deprecation markers) and a `3.1.0` CHANGELOG entry.

The library already supported the other RFC 9989 additions (`np`, `psd`, `t`), so this closes the remaining gap.

Removal of `pct`/`interval` and migrating `$rua`/`$ruf` to array-typed properties are intentionally deferred to a future major release.

## Test Plan

- [x] New tests cover: array input for `rua`/`ruf`, single-string still works, whitespace trimming, empty-array clears, per-item `mailto:` validation, multi-address render, and parse round-trip
- [x] CI green on PHP 8.2 / 8.3 / 8.4 (prefer-lowest & prefer-stable)

Closes #36