### PR TITLE
feat!: 4.0 — drop runtime dependencies and remove deprecated pct()/interval()

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.3, 8.4]
+        php: [8.3, 8.4, 8.5]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ A PHP package for building and parsing DMARC DNS records with a fluent, human-fr
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
+
+This package has no runtime dependencies.
 
 ## Installation
 
@@ -40,19 +42,17 @@ $record = new DmarcRecord();
 
 $record->policy('reject')
     ->subdomainPolicy('quarantine')
-    ->pct(100)
     ->rua('mailto:dmarc@example.com')
     ->ruf('mailto:dmarc-forensic@example.com')
     ->adkim('relaxed')
     ->aspf('strict')
     ->reporting(['dkim', 'spf'])
-    ->interval(86400)
     ->nonExistentSubdomainPolicy('reject')
     ->publicSuffixDomainPolicy('y')
     ->testingMode('n');
 
 echo $record;
-// v=DMARC1; p=reject; sp=quarantine; pct=100; rua=mailto:dmarc@example.com; ruf=mailto:dmarc-forensic@example.com; adkim=r; aspf=s; fo=d:s; ri=86400; np=reject; psd=y; t=n
+// v=DMARC1; p=reject; sp=quarantine; rua=mailto:dmarc@example.com; ruf=mailto:dmarc-forensic@example.com; adkim=r; aspf=s; fo=d:s; np=reject; psd=y; t=n
 ```
 
 ### Constructor
@@ -64,13 +64,11 @@ $record = new DmarcRecord(
     version: 'DMARC1',
     policy: 'reject',
     subdomain_policy: 'quarantine',
-    pct: 100,
     rua: 'mailto:dmarc@example.com',
     ruf: 'mailto:dmarc-forensic@example.com',
     adkim: 'relaxed',
     aspf: 'strict',
     reporting: ['dkim', 'spf'],
-    interval: 86400,
     np: 'reject',
     psd: 'y',
     t: 'n',
@@ -84,11 +82,10 @@ $record = new DmarcRecord(
 ```php
 $record = (string) DmarcRecord::create(
     policy: 'quarantine',
-    pct: 20,
     rua: 'mailto:dmarc@example.com',
 );
 
-// v=DMARC1; p=quarantine; pct=20; rua=mailto:dmarc@example.com
+// v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com
 ```
 
 ## Parsing an Existing Record
@@ -114,7 +111,7 @@ echo $record;
 // v=DMARC1; p=reject; rua=mailto:dmarc@example.com
 ```
 
-`parse()` requires both `v` and `p` tags to be present and will throw an `InvalidArgumentException` if either is missing. Unknown tags are silently ignored.
+`parse()` requires both `v` and `p` tags to be present and will throw an `InvalidDmarcRecordException` if either is missing. Unknown tags are silently ignored.
 
 ## Tag Reference
 
@@ -123,20 +120,18 @@ echo $record;
 | `version()` | `v` | `'DMARC1'` | `'DMARC1'` |
 | `policy()` | `p` | `'none'`, `'quarantine'`, `'reject'` | `'none'` |
 | `subdomainPolicy()` | `sp` | `'none'`, `'quarantine'`, `'reject'` | `null` |
-| `pct()` | `pct` | Integer | `null` |
 | `rua()` | `rua` | `'mailto:...'` | `null` |
 | `ruf()` | `ruf` | `'mailto:...'` | `null` |
 | `adkim()` | `adkim` | `'relaxed'`, `'strict'` | `null` |
 | `aspf()` | `aspf` | `'relaxed'`, `'strict'` | `null` |
 | `reporting()` | `fo` | `'all'`, `'any'`, `'dkim'`, `'spf'` | `[]` |
-| `interval()` | `ri` | Integer (seconds) | `null` |
 | `nonExistentSubdomainPolicy()` | `np` | `'none'`, `'quarantine'`, `'reject'` | `null` |
 | `publicSuffixDomainPolicy()` | `psd` | `'y'`, `'n'`, `'u'` | `null` |
 | `testingMode()` | `t` | `'y'`, `'n'` | `null` |
 
 Tags with a `null` value are omitted from the output string. Only `v` and `p` are always emitted.
 
-> **Note:** RFC 9989 (DMARCbis) removed the `pct` and `ri` tags. `pct()` and `interval()` are deprecated and retained only for backwards compatibility; they are scheduled for removal in `4.0.0`.
+> **Note:** RFC 9989 (DMARCbis) removed the `pct` and `ri` tags, so this package no longer supports them (removed in `4.0.0`). Records that still contain those tags parse without error — the tags are simply ignored.
 
 ### Tag Details
 
@@ -151,12 +146,6 @@ Controls how the receiving mail server handles messages that fail DMARC checks.
 `subdomainPolicy()` (`sp`) overrides `policy()` for subdomains. If omitted, subdomains inherit the main policy.
 
 `nonExistentSubdomainPolicy()` (`np`) applies to non-existent subdomains (RFC 9091 / DMARCbis). Takes precedence over both `policy()` and `subdomainPolicy()` for those domains.
-
-#### `pct()`
-
-> **Deprecated (RFC 9989)** — DMARCbis removed the `pct` tag. Still functional; scheduled for removal in `4.0.0`.
-
-The percentage of messages the policy is applied to (1–100). Useful for gradual rollout. Omit to apply the policy to all messages.
 
 #### `rua()` / `ruf()`
 
@@ -207,13 +196,7 @@ Multiple values produce a colon-separated `fo` tag:
 // fo=1
 ```
 
-Duplicate values are silently deduplicated. `'all'` and `'any'` are mutually exclusive — passing both throws an `InvalidArgumentException`.
-
-#### `interval()`
-
-> **Deprecated (RFC 9989)** — DMARCbis removed the `ri` tag. Still functional; scheduled for removal in `4.0.0`.
-
-How often (in seconds) receivers should send aggregate reports. The RFC default is 86400 (24 hours).
+Duplicate values are silently deduplicated. `'all'` and `'any'` are mutually exclusive — passing both throws an `InvalidDmarcRecordException`.
 
 #### `publicSuffixDomainPolicy()`
 
@@ -229,16 +212,16 @@ When set to `'y'`, signals that DMARC is in testing mode. Receivers should not a
 
 ## Validation
 
-The package validates inputs on each setter call. Passing an invalid value throws an `InvalidArgumentException` from `webmozart/assert`.
+The package validates inputs on each setter call. Passing an invalid value throws a `CbowOfRivia\DmarcRecordBuilder\Exceptions\InvalidDmarcRecordException`. It extends the native `\InvalidArgumentException`, so existing `catch (\InvalidArgumentException)` handlers continue to work.
 
 ```php
-// Throws: Expected one of: "none", "quarantine", "reject", NULL. Got: "monitor"
+// Throws: Expected one of: "none", "quarantine", "reject", null. Got: "monitor"
 $record->policy('monitor');
 
 // Throws: rua mailto address should start with "mailto:"
 $record->rua('dmarc@example.com');
 
-// Throws: Expected one of: "relaxed", "strict", NULL. Got: "loose"
+// Throws: Expected one of: "relaxed", "strict", null. Got: "loose"
 $record->adkim('loose');
 
 // Throws: Reporting options "all" (0) and "any" (1) are mutually exclusive.

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/collections": "^12.0",
-        "webmozart/assert": "^2.1"
+        "php": "^8.3"
     },
     "require-dev": {
         "laravel/pint": "^1.15",

--- a/src/DmarcRecord.php
+++ b/src/DmarcRecord.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace CbowOfRivia\DmarcRecordBuilder;
 
-use Illuminate\Support\Collection;
-use Webmozart\Assert\Assert;
+use CbowOfRivia\DmarcRecordBuilder\Exceptions\InvalidDmarcRecordException;
 
 /**
  * Responsible for building an object representation of a DMARC
@@ -21,8 +20,6 @@ class DmarcRecord
 
     public ?string $subdomain_policy = null;
 
-    public ?int $pct = null;
-
     public ?string $rua = null;
 
     public ?string $ruf = null;
@@ -32,8 +29,6 @@ class DmarcRecord
     public ?string $aspf = null;
 
     public array $reporting = [];
-
-    public ?int $interval = null;
 
     public ?string $np = null;
 
@@ -45,13 +40,11 @@ class DmarcRecord
         string $version = 'DMARC1',
         ?string $policy = 'none',
         ?string $subdomain_policy = null,
-        ?int $pct = null,
         string|array|null $rua = null,
         string|array|null $ruf = null,
         ?string $adkim = null,
         ?string $aspf = null,
         string|array $reporting = [],
-        ?int $interval = null,
         ?string $np = null,
         ?string $psd = null,
         ?string $t = null
@@ -59,13 +52,11 @@ class DmarcRecord
         $this->version($version);
         $this->policy($policy);
         $this->subdomainPolicy($subdomain_policy);
-        $this->pct($pct);
         $this->rua($rua);
         $this->ruf($ruf);
         $this->adkim($adkim);
         $this->aspf($aspf);
         $this->reporting($reporting);
-        $this->interval($interval);
         $this->nonExistentSubdomainPolicy($np);
         $this->publicSuffixDomainPolicy($psd);
         $this->testingMode($t);
@@ -83,7 +74,7 @@ class DmarcRecord
 
     public function policy(?string $policy): static
     {
-        Assert::inArray($policy, [
+        InvalidDmarcRecordException::inArray($policy, [
             'none', 'quarantine', 'reject', null,
         ]);
 
@@ -94,22 +85,11 @@ class DmarcRecord
 
     public function subdomainPolicy(?string $policy): static
     {
-        Assert::inArray($policy, [
+        InvalidDmarcRecordException::inArray($policy, [
             'none', 'quarantine', 'reject', null,
         ]);
 
         $this->subdomain_policy = $policy;
-
-        return $this;
-    }
-
-    /**
-     * @deprecated RFC 9989 (DMARCbis) removed the "pct" tag. Retained for
-     *             backwards compatibility; scheduled for removal in 4.0.0.
-     */
-    public function pct(?int $percentage): static
-    {
-        $this->pct = $percentage;
 
         return $this;
     }
@@ -138,7 +118,7 @@ class DmarcRecord
         ));
 
         foreach ($items as $item) {
-            Assert::startsWith(
+            InvalidDmarcRecordException::startsWith(
                 value: $item,
                 prefix: 'mailto:',
                 message: sprintf('%s mailto address should start with "mailto:"', $tag)
@@ -150,7 +130,7 @@ class DmarcRecord
 
     public function adkim(?string $value): static
     {
-        Assert::inArray($value, [
+        InvalidDmarcRecordException::inArray($value, [
             'relaxed', 'strict', null,
         ]);
 
@@ -161,7 +141,7 @@ class DmarcRecord
 
     public function aspf(?string $value): static
     {
-        Assert::inArray($value, [
+        InvalidDmarcRecordException::inArray($value, [
             'relaxed', 'strict', null,
         ]);
 
@@ -178,10 +158,10 @@ class DmarcRecord
 
         $values = array_values(array_unique($values));
 
-        Assert::allInArray($values, ['all', 'any', 'dkim', 'spf']);
+        InvalidDmarcRecordException::allInArray($values, ['all', 'any', 'dkim', 'spf']);
 
-        Assert::false(
-            value: in_array('all', $values) && in_array('any', $values),
+        InvalidDmarcRecordException::throwIf(
+            condition: in_array('all', $values) && in_array('any', $values),
             message: 'Reporting options "all" (0) and "any" (1) are mutually exclusive.'
         );
 
@@ -190,20 +170,9 @@ class DmarcRecord
         return $this;
     }
 
-    /**
-     * @deprecated RFC 9989 (DMARCbis) removed the "ri" tag. Retained for
-     *             backwards compatibility; scheduled for removal in 4.0.0.
-     */
-    public function interval(?int $interval): static
-    {
-        $this->interval = $interval;
-
-        return $this;
-    }
-
     public function nonExistentSubdomainPolicy(?string $policy): static
     {
-        Assert::inArray($policy, [
+        InvalidDmarcRecordException::inArray($policy, [
             'none', 'quarantine', 'reject', null,
         ]);
 
@@ -214,7 +183,7 @@ class DmarcRecord
 
     public function publicSuffixDomainPolicy(?string $policy): static
     {
-        Assert::inArray($policy, [
+        InvalidDmarcRecordException::inArray($policy, [
             'y', 'n', 'u', null,
         ]);
 
@@ -225,7 +194,7 @@ class DmarcRecord
 
     public function testingMode(?string $testingMode): static
     {
-        Assert::inArray($testingMode, [
+        InvalidDmarcRecordException::inArray($testingMode, [
             'y', 'n', null,
         ]);
 
@@ -238,13 +207,11 @@ class DmarcRecord
         string $version = 'DMARC1',
         ?string $policy = 'none',
         ?string $subdomain_policy = null,
-        ?int $pct = null,
         string|array|null $rua = null,
         string|array|null $ruf = null,
         ?string $adkim = null,
         ?string $aspf = null,
         string|array $reporting = [],
-        ?int $interval = null,
         ?string $np = null,
         ?string $psd = null,
         ?string $t = null
@@ -253,13 +220,11 @@ class DmarcRecord
             version: $version,
             policy: $policy,
             subdomain_policy: $subdomain_policy,
-            pct: $pct,
             rua: $rua,
             ruf: $ruf,
             adkim: $adkim,
             aspf: $aspf,
             reporting: $reporting,
-            interval: $interval,
             np: $np,
             psd: $psd,
             t: $t
@@ -270,25 +235,26 @@ class DmarcRecord
     {
         $builder = new static;
 
-        collect(explode(';', $record))
-            ->mapWithKeys(function (string $part) {
-                $property = explode('=', trim($part));
+        $properties = [];
 
-                if (count($property) !== 2) {
-                    return [];
-                }
+        foreach (explode(';', $record) as $part) {
+            $property = explode('=', trim($part));
 
-                return [$property[0] => $property[1]];
-            })
-            ->tap(function (Collection $properties): void {
-                Assert::keyExists($properties->toArray(), 'v', 'DMARC version is required');
-                Assert::keyExists($properties->toArray(), 'p', 'DMARC policy is required');
-            })
-            ->each(fn (string $value, $key) => match ($key) {
+            if (count($property) !== 2) {
+                continue;
+            }
+
+            $properties[$property[0]] = $property[1];
+        }
+
+        InvalidDmarcRecordException::keyExists($properties, 'v', 'DMARC version is required');
+        InvalidDmarcRecordException::keyExists($properties, 'p', 'DMARC policy is required');
+
+        foreach ($properties as $key => $value) {
+            match ($key) {
                 'v' => $builder->version($value),
                 'p' => $builder->policy($value),
                 'sp' => $builder->subdomainPolicy($value),
-                'pct' => $builder->pct((int) $value),
                 'rua' => $builder->rua($value),
                 'ruf' => $builder->ruf($value),
                 'adkim' => $builder->adkim($builder->getHumanAdkimValue($value)),
@@ -297,12 +263,12 @@ class DmarcRecord
                     fn (string $v) => $builder->getHumanReportingOption(trim($v)),
                     explode(':', $value)
                 )),
-                'ri' => $builder->interval((int) $value),
                 'np' => $builder->nonExistentSubdomainPolicy($value),
                 'psd' => $builder->publicSuffixDomainPolicy($value),
                 't' => $builder->testingMode($value),
                 default => null,
-            });
+            };
+        }
 
         return $builder;
     }
@@ -338,13 +304,11 @@ class DmarcRecord
         $record = $this->version ? "v=$this->version; " : '';
         $record .= $this->policy ? "p=$this->policy; " : '';
         $record .= $this->subdomain_policy ? "sp=$this->subdomain_policy; " : '';
-        $record .= $this->pct ? "pct=$this->pct; " : '';
         $record .= $this->rua ? "rua=$this->rua; " : '';
         $record .= $this->ruf ? "ruf=$this->ruf; " : '';
         $record .= $this->adkim ? "adkim={$this->getRealAdkimValue($this->adkim)}; " : '';
         $record .= $this->aspf ? "aspf={$this->getRealAspfValue($this->aspf)}; " : '';
         $record .= $this->reporting ? 'fo='.implode(':', array_map(fn (string $v) => $this->getRealReportingOption($v), $this->reporting)).'; ' : '';
-        $record .= $this->interval ? "ri=$this->interval; " : '';
         $record .= $this->np ? "np=$this->np; " : '';
         $record .= $this->psd ? "psd=$this->psd; " : '';
         $record .= $this->t ? "t=$this->t; " : '';

--- a/src/Exceptions/InvalidDmarcRecordException.php
+++ b/src/Exceptions/InvalidDmarcRecordException.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CbowOfRivia\DmarcRecordBuilder\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * Thrown when a tag is given a disallowed value, or a required tag is missing
+ * while parsing. Extends \InvalidArgumentException so existing
+ * `catch (\InvalidArgumentException)` handlers keep working.
+ *
+ * The static guards validate input and throw on failure. The inArray message
+ * mirrors the wording emitted before 4.0, so callers matching on exception
+ * text are unaffected.
+ */
+class InvalidDmarcRecordException extends InvalidArgumentException
+{
+    /**
+     * @param  array<int, mixed>  $allowed
+     */
+    public static function inArray(mixed $value, array $allowed): void
+    {
+        if (! in_array($value, $allowed, true)) {
+            throw new self(sprintf(
+                'Expected one of: %2$s. Got: %s',
+                self::stringify($value),
+                implode(', ', array_map([self::class, 'stringify'], $allowed)),
+            ));
+        }
+    }
+
+    /**
+     * @param  iterable<mixed>  $values
+     * @param  array<int, mixed>  $allowed
+     */
+    public static function allInArray(iterable $values, array $allowed): void
+    {
+        foreach ($values as $value) {
+            self::inArray($value, $allowed);
+        }
+    }
+
+    public static function startsWith(string $value, string $prefix, string $message): void
+    {
+        if (! str_starts_with($value, $prefix)) {
+            throw new self($message);
+        }
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $array
+     */
+    public static function keyExists(array $array, int|string $key, string $message): void
+    {
+        if (! array_key_exists($key, $array)) {
+            throw new self($message);
+        }
+    }
+
+    public static function throwIf(bool $condition, string $message): void
+    {
+        if ($condition) {
+            throw new self($message);
+        }
+    }
+
+    private static function stringify(mixed $value): string
+    {
+        return $value === null ? 'null' : '"'.$value.'"';
+    }
+}

--- a/tests/DmarcRecordTest.php
+++ b/tests/DmarcRecordTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use CbowOfRivia\DmarcRecordBuilder\DmarcRecord;
-use Webmozart\Assert\InvalidArgumentException;
+use CbowOfRivia\DmarcRecordBuilder\Exceptions\InvalidDmarcRecordException;
 
 beforeEach(function (): void {
     $this->record = new DmarcRecord;
@@ -19,26 +19,22 @@ describe('constructor', function (): void {
             version: 'DMARC1',
             policy: 'quarantine',
             subdomain_policy: 'reject',
-            pct: 50,
             rua: 'mailto:test@example.com',
             ruf: 'mailto:test@example.com',
             adkim: 'strict',
             aspf: 'relaxed',
             reporting: ['dkim'],
-            interval: 7200
         );
 
         expect($record)
             ->version->toEqual('DMARC1')
             ->policy->toEqual('quarantine')
             ->subdomain_policy->toEqual('reject')
-            ->pct->toEqual(50)
             ->rua->toEqual('mailto:test@example.com')
             ->ruf->toEqual('mailto:test@example.com')
             ->adkim->toEqual('strict')
             ->aspf->toEqual('relaxed')
-            ->reporting->toEqual(['dkim'])
-            ->interval->toEqual(7200);
+            ->reporting->toEqual(['dkim']);
     });
 
     it('constructs with np, psd, and t parameters', function (): void {
@@ -46,13 +42,11 @@ describe('constructor', function (): void {
             version: 'DMARC1',
             policy: 'quarantine',
             subdomain_policy: 'reject',
-            pct: 50,
             rua: 'mailto:test@example.com',
             ruf: 'mailto:test@example.com',
             adkim: 'strict',
             aspf: 'relaxed',
             reporting: ['dkim'],
-            interval: 7200,
             np: 'reject',
             psd: 'y',
             t: 'n'
@@ -73,26 +67,22 @@ describe('fluent methods', function (): void {
             ->version('DMARC1')
             ->policy('quarantine')
             ->subdomainPolicy('reject')
-            ->pct(75)
             ->rua('mailto:test@example.com')
             ->ruf('mailto:test@example.com')
             ->adkim('strict')
             ->aspf('relaxed')
-            ->reporting(['spf'])
-            ->interval(1800);
+            ->reporting(['spf']);
 
         expect($result)->toBe($record);
         expect($record)
             ->version->toEqual('DMARC1')
             ->policy->toEqual('quarantine')
             ->subdomain_policy->toEqual('reject')
-            ->pct->toEqual(75)
             ->rua->toEqual('mailto:test@example.com')
             ->ruf->toEqual('mailto:test@example.com')
             ->adkim->toEqual('strict')
             ->aspf->toEqual('relaxed')
-            ->reporting->toEqual(['spf'])
-            ->interval->toEqual(1800);
+            ->reporting->toEqual(['spf']);
     });
 
     it('handles null values in all methods', function (string $method, mixed $value, string $property): void {
@@ -113,12 +103,10 @@ describe('fluent methods', function (): void {
         ['version', 'DMARC1', 'version'],
         ['policy', 'quarantine', 'policy'],
         ['subdomainPolicy', 'reject', 'subdomain_policy'],
-        ['pct', 50, 'pct'],
         ['rua', 'mailto:test@example.com', 'rua'],
         ['ruf', 'mailto:test@example.com', 'ruf'],
         ['adkim', 'relaxed', 'adkim'],
         ['aspf', 'strict', 'aspf'],
-        ['interval', 3600, 'interval'],
         ['nonExistentSubdomainPolicy', 'reject', 'np'],
         ['publicSuffixDomainPolicy', 'y', 'psd'],
         ['testingMode', 'y', 't'],
@@ -176,17 +164,17 @@ describe('fluent methods', function (): void {
 describe('validation', function (): void {
     it('rejects invalid policy values', function (string $invalidPolicy): void {
         expect(fn () => DmarcRecord::create(policy: $invalidPolicy))
-            ->toThrow(InvalidArgumentException::class);
+            ->toThrow(InvalidDmarcRecordException::class);
     })->with(['invalid', 'bad', 'wrong']);
 
     it('rejects invalid subdomain policy values', function (string $invalidPolicy): void {
         expect(fn () => DmarcRecord::create(subdomain_policy: $invalidPolicy))
-            ->toThrow(InvalidArgumentException::class);
+            ->toThrow(InvalidDmarcRecordException::class);
     })->with(['invalid', 'bad', 'wrong']);
 
     it('rejects malformed rua addresses', function (string $invalidRua): void {
         expect(fn () => DmarcRecord::create(rua: $invalidRua))
-            ->toThrow(InvalidArgumentException::class, 'rua mailto address should start with "mailto:"');
+            ->toThrow(InvalidDmarcRecordException::class, 'rua mailto address should start with "mailto:"');
     })->with([
         'no-mailto@mailto.com',
         'test@test.com',
@@ -195,7 +183,7 @@ describe('validation', function (): void {
 
     it('rejects malformed ruf addresses', function (string $invalidRuf): void {
         expect(fn () => DmarcRecord::create(ruf: $invalidRuf))
-            ->toThrow(InvalidArgumentException::class, 'ruf mailto address should start with "mailto:"');
+            ->toThrow(InvalidDmarcRecordException::class, 'ruf mailto address should start with "mailto:"');
     })->with([
         'test@test.com',
         'invalid-format',
@@ -204,22 +192,22 @@ describe('validation', function (): void {
 
     it('rejects invalid adkim values', function (string $invalidAdkim): void {
         expect(fn () => DmarcRecord::create(adkim: $invalidAdkim))
-            ->toThrow(InvalidArgumentException::class);
+            ->toThrow(InvalidDmarcRecordException::class);
     })->with(['naughty', 'invalid', 'bad']);
 
     it('rejects invalid aspf values', function (string $invalidAspf): void {
         expect(fn () => DmarcRecord::create(aspf: $invalidAspf))
-            ->toThrow(InvalidArgumentException::class);
+            ->toThrow(InvalidDmarcRecordException::class);
     })->with(['naughty', 'invalid', 'bad']);
 
     it('rejects invalid reporting values', function (string|array $invalidReporting): void {
         expect(fn () => DmarcRecord::create(reporting: $invalidReporting))
-            ->toThrow(InvalidArgumentException::class);
+            ->toThrow(InvalidDmarcRecordException::class);
     })->with(['invalid', 'bad', 'wrong', ['invalid'], ['bad'], ['wrong']]);
 
     it('rejects mutually exclusive reporting values all and any', function (): void {
         expect(fn () => DmarcRecord::create(reporting: ['all', 'any']))
-            ->toThrow(InvalidArgumentException::class, 'mutually exclusive');
+            ->toThrow(InvalidDmarcRecordException::class, 'mutually exclusive');
     });
 
     it('deduplicates reporting values silently', function (): void {
@@ -230,27 +218,27 @@ describe('validation', function (): void {
 
     it('rejects invalid np values', function (string $invalidNp): void {
         expect(fn () => DmarcRecord::create(np: $invalidNp))
-            ->toThrow(InvalidArgumentException::class);
+            ->toThrow(InvalidDmarcRecordException::class);
     })->with(['invalid', 'bad', 'wrong']);
 
     it('rejects invalid psd values', function (string $invalidPsd): void {
         expect(fn () => DmarcRecord::create(psd: $invalidPsd))
-            ->toThrow(InvalidArgumentException::class);
+            ->toThrow(InvalidDmarcRecordException::class);
     })->with(['z', 'invalid', 'bad']);
 
     it('rejects invalid t values', function (string $invalidT): void {
         expect(fn () => DmarcRecord::create(t: $invalidT))
-            ->toThrow(InvalidArgumentException::class);
+            ->toThrow(InvalidDmarcRecordException::class);
     })->with(['x', 'invalid', 'bad']);
 
     it('rejects an array containing a non-mailto rua address', function (): void {
         expect(fn () => DmarcRecord::create(rua: ['mailto:a@example.com', 'invalid@example.com']))
-            ->toThrow(InvalidArgumentException::class, 'rua mailto address should start with "mailto:"');
+            ->toThrow(InvalidDmarcRecordException::class, 'rua mailto address should start with "mailto:"');
     });
 
     it('rejects an array containing a non-mailto ruf address', function (): void {
         expect(fn () => DmarcRecord::create(ruf: ['mailto:a@example.com', 'invalid@example.com']))
-            ->toThrow(InvalidArgumentException::class, 'ruf mailto address should start with "mailto:"');
+            ->toThrow(InvalidDmarcRecordException::class, 'ruf mailto address should start with "mailto:"');
     });
 });
 
@@ -265,16 +253,14 @@ describe('string output', function (): void {
             version: 'DMARC1',
             policy: 'reject',
             subdomain_policy: 'quarantine',
-            pct: 75,
             rua: 'mailto:test@example.com',
             ruf: 'mailto:test@example.com',
             adkim: 'strict',
             aspf: 'relaxed',
             reporting: ['all'],
-            interval: 3600
         );
 
-        $expected = 'v=DMARC1; p=reject; sp=quarantine; pct=75; rua=mailto:test@example.com; ruf=mailto:test@example.com; adkim=s; aspf=r; fo=0; ri=3600;';
+        $expected = 'v=DMARC1; p=reject; sp=quarantine; rua=mailto:test@example.com; ruf=mailto:test@example.com; adkim=s; aspf=r; fo=0;';
         expect((string) $record)->toEqual($expected);
     });
 
@@ -315,13 +301,11 @@ describe('string output', function (): void {
         $record->version('DMARC1')
             ->policy('none')
             ->subdomainPolicy(null)
-            ->pct(null)
             ->rua(null)
             ->ruf(null)
             ->adkim(null)
             ->aspf(null)
-            ->reporting([])
-            ->interval(null);
+            ->reporting([]);
 
         expect((string) $record)->toEqual('v=DMARC1; p=none;');
     });
@@ -330,7 +314,6 @@ describe('string output', function (): void {
         $record = new DmarcRecord;
         $record->version('DMARC1')
             ->policy('quarantine')
-            ->pct(50)
             ->rua('mailto:test@example.com')
             ->adkim('relaxed');
 
@@ -338,14 +321,12 @@ describe('string output', function (): void {
         expect($output)
             ->toContain('v=DMARC1;')
             ->toContain('p=quarantine;')
-            ->toContain('pct=50;')
             ->toContain('rua=mailto:test@example.com;')
             ->toContain('adkim=r')
             ->not->toContain('sp=')
             ->not->toContain('ruf=')
             ->not->toContain('aspf=')
-            ->not->toContain('fo=')
-            ->not->toContain('ri=');
+            ->not->toContain('fo=');
     });
 
     it('trims trailing spaces and ends with semicolon', function (): void {
@@ -381,7 +362,7 @@ describe('string output', function (): void {
 
 describe('parsing', function (): void {
     it('parses complete record correctly', function (): void {
-        $record = 'v=DMARC1; p=none; sp=none; pct=100; rua=mailto:example@example.com; ruf=mailto:example@example.com; adkim=r; aspf=r; ri=3600;';
+        $record = 'v=DMARC1; p=none; sp=none; rua=mailto:example@example.com; ruf=mailto:example@example.com; adkim=r; aspf=r;';
         $instance = DmarcRecord::parse($record);
 
         expect($instance)
@@ -389,12 +370,10 @@ describe('parsing', function (): void {
             ->version->toEqual('DMARC1')
             ->policy->toEqual('none')
             ->subdomain_policy->toEqual('none')
-            ->pct->toEqual(100)
             ->rua->toEqual('mailto:example@example.com')
             ->ruf->toEqual('mailto:example@example.com')
             ->adkim->toEqual('relaxed')
             ->aspf->toEqual('relaxed')
-            ->interval->toEqual(3600)
             ->and((string) $instance)
             ->toEqual($record);
     });
@@ -424,13 +403,11 @@ describe('parsing', function (): void {
             ->version->toEqual('DMARC1')
             ->policy->toEqual('none')
             ->subdomain_policy->toBeNull()
-            ->pct->toBeNull()
             ->rua->toBeNull()
             ->ruf->toBeNull()
             ->adkim->toBeNull()
             ->aspf->toBeNull()
-            ->reporting->toEqual([])
-            ->interval->toBeNull();
+            ->reporting->toEqual([]);
     });
 
     it('parses single fo value', function (): void {
@@ -457,16 +434,16 @@ describe('parsing', function (): void {
         }
     })->with([
         [
-            '  v=DMARC1;  p=quarantine;  sp=reject;  pct=50;  ',
-            ['version' => 'DMARC1', 'policy' => 'quarantine', 'subdomain_policy' => 'reject', 'pct' => 50],
+            '  v=DMARC1;  p=quarantine;  sp=reject;  ',
+            ['version' => 'DMARC1', 'policy' => 'quarantine', 'subdomain_policy' => 'reject'],
         ],
         [
-            'v=DMARC1; p=quarantine; ; pct=50;',
-            ['version' => 'DMARC1', 'policy' => 'quarantine', 'pct' => 50],
+            'v=DMARC1; p=quarantine; ; sp=reject;',
+            ['version' => 'DMARC1', 'policy' => 'quarantine', 'subdomain_policy' => 'reject'],
         ],
         [
-            'v=DMARC1; p=quarantine; invalid-part; pct=50;',
-            ['version' => 'DMARC1', 'policy' => 'quarantine', 'pct' => 50],
+            'v=DMARC1; p=quarantine; invalid-part; sp=reject;',
+            ['version' => 'DMARC1', 'policy' => 'quarantine', 'subdomain_policy' => 'reject'],
         ],
         [
             'v=DMARC1; p=quarantine; adkim=r; aspf=s; fo=d;',
@@ -495,9 +472,14 @@ describe('parsing', function (): void {
         expect($instance->policy)->toEqual('none');
     });
 
+    it('drops the removed pct and ri tags when parsing', function (): void {
+        $instance = DmarcRecord::parse('v=DMARC1; p=none; pct=50; ri=3600;');
+        expect((string) $instance)->toBe('v=DMARC1; p=none;');
+    });
+
     it('fails with missing required fields', function (string $record, string $expectedException): void {
         expect(fn () => DmarcRecord::parse($record))
-            ->toThrow(InvalidArgumentException::class, $expectedException);
+            ->toThrow(InvalidDmarcRecordException::class, $expectedException);
     })->with([
         ['p=none;', 'DMARC version is required'],
         ['v=DMARC1;', 'DMARC policy is required'],
@@ -507,7 +489,7 @@ describe('parsing', function (): void {
 
     it('fails with invalid field values', function (string $record, string $expectedException): void {
         expect(fn () => DmarcRecord::parse($record))
-            ->toThrow(InvalidArgumentException::class, $expectedException);
+            ->toThrow(InvalidDmarcRecordException::class, $expectedException);
     })->with([
         ['v=DMARC1; p=invalid;', 'Expected one of: "none", "quarantine", "reject", null. Got: "invalid"'],
         ['v=DMARC1; p=none; sp=invalid;', 'Expected one of: "none", "quarantine", "reject", null. Got: "invalid"'],
@@ -531,13 +513,11 @@ describe('static factory methods', function (): void {
             version: 'none',
             policy: 'reject',
             subdomain_policy: 'reject',
-            pct: 100,
             rua: 'mailto:example@example.com',
             ruf: 'mailto:example@example.com',
             adkim: 'relaxed',
             aspf: 'relaxed',
             reporting: ['any'],
-            interval: 3600,
         );
 
         expect($record)
@@ -545,12 +525,10 @@ describe('static factory methods', function (): void {
             ->version->toEqual('none')
             ->policy->toEqual('reject')
             ->subdomain_policy->toEqual('reject')
-            ->pct->toEqual(100)
             ->rua->toEqual('mailto:example@example.com')
             ->ruf->toEqual('mailto:example@example.com')
             ->adkim->toEqual('relaxed')
             ->aspf->toEqual('relaxed')
-            ->interval->toEqual(3600)
             ->reporting->toEqual(['any']);
     });
 });


### PR DESCRIPTION
## Why this PR

The 4.0 work was merged via #38 into `feature/rfc-9989-rua-ruf-lists` instead of `main` (the expected auto-retarget didn't fire after #37 squash-merged). This PR lands it on `main`.

It is the 4.0 squash commit from #38 cherry-picked onto `main`, so the diff is **only** the 4.0 changes — `main`'s independent updates (dependabot `fetch-metadata`, `codecov-action@v7`) are preserved, not reverted.

## Changes

1. **Drop `webmozart/assert` and `illuminate/collections` runtime dependencies** — the package now ships dependency-free.
   - Validation lives on `InvalidDmarcRecordException` as static guards (`inArray`, `allInArray`, `startsWith`, `keyExists`, `throwIf`); it extends `\InvalidArgumentException` so existing `catch (\InvalidArgumentException)` handlers keep working. Messages are unchanged.
   - `parse()` rewritten with plain-array loops instead of `illuminate/collections`.
   - PHP floor raised to `^8.3` (8.2 reaches EOL Dec 2026); CI matrix now 8.3/8.4/8.5.

2. **Remove the deprecated `pct()` and `interval()` tags** (RFC 9989 / DMARCbis). `parse()` now treats `pct`/`ri` as unknown tags — older records still parse, the tags drop on re-cast.

## Breaking changes

- Code catching `Webmozart\Assert\InvalidArgumentException` by name must catch `\InvalidArgumentException` (or `InvalidDmarcRecordException`) instead.
- Minimum PHP is now **8.3**.
- `pct()` / `interval()`, their constructor + `create()` arguments, and the `$pct` / `$interval` properties are removed.

## Testing

- `vendor/bin/pest` — 107 passing
- `vendor/bin/pint --test` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)